### PR TITLE
Fix warning: deprecated directive, use '%name-prefix [-Wdeprecated]

### DIFF
--- a/dcerpc/idl_compiler/acf_y.y
+++ b/dcerpc/idl_compiler/acf_y.y
@@ -281,7 +281,7 @@ static void acf_warning
 %defines
 %error-verbose
 %pure-parser
-%name-prefix="acf_yy"
+%name-prefix "acf_yy"
 
 /* Tell Bison that the Flexer takes a yyscan_t parameter. */
 %lex-param { void * lexxer }

--- a/dcerpc/idl_compiler/nidl_y.y
+++ b/dcerpc/idl_compiler/nidl_y.y
@@ -133,7 +133,7 @@ static void nidl_yyerror (YYLTYPE *, nidl_parser_p, char const *);
 %defines
 %error-verbose
 %pure-parser
-%name-prefix="nidl_yy"
+%name-prefix "nidl_yy"
 
 /* Tell Bison that the Flexer takes a yyscan_t parameter. */
 %lex-param { void * lexxer }


### PR DESCRIPTION
Fix: warning: deprecated directive, use ‘%name-prefix’ [-Wdeprecated]
