### PR TITLE
Use standard CFString API on Darwin.

### DIFF
--- a/dcerpc/dcelib/darwin/wc16str.h
+++ b/dcerpc/dcelib/darwin/wc16str.h
@@ -46,5 +46,10 @@
  **
  */
 
+#ifndef _WC16STR_H_
+#define _WC16STR_H_
+
 char *awc16stombs(const wchar16_t * input);
 wchar16_t *ambstowc16s(const char * input);
+
+#endif /* _WC16STR_H_ */

--- a/dcerpc/dcelib/mswrappers.c
+++ b/dcerpc/dcelib/mswrappers.c
@@ -84,7 +84,7 @@
 
 #if HAVE_WC16STR_H
 #include <wc16str.h>
-#elif HAVE_COREFOUNDATION_CFSTRINGENCODINGCONVERTER_H
+#else
 #include "wc16str.h"
 #endif
 

--- a/dcerpc/m4/rpc_libunistr.m4
+++ b/dcerpc/m4/rpc_libunistr.m4
@@ -57,20 +57,24 @@ AC_SEARCH_LIBS(ambstowc16s, unistr,
 	    LDFLAGS=
 	    LIBS=
 
-	    AC_CHECK_HEADERS([CoreFoundation/CFStringEncodingConverter.h],
+	    AC_CHECK_HEADERS([CoreFoundation/CoreFoundation.h],
 	    [
 		LIBS="-framework CoreFoundation"
 		AC_LINK_IFELSE(
                 [
                     AC_LANG_PROGRAM(
                         [
-			    #include <CoreFoundation/CFStringEncodingConverter.h>
+			    #include <CoreFoundation/CoreFoundation.h>
                         ], [
-			    CFStringEncodingBytesToUnicode(
-				0 /* encoding */, 0 /* flags */,
-				NULL /* bytes */, 0 /* numBytes */,
-				NULL /* usedByteLen */, NULL /* characters */,
-				0 /* maxCharLen */, NULL /* usedCharLen */);
+                            CFStringGetBytes(
+                                NULL /* theString */,
+                                CFRangeMake(0, 0) /*range */,
+                                kCFStringEncodingUTF8,
+                                0 /* lossByte */,
+                                0 /* isExternalRepresentation */,
+                                NULL /* buffer */,
+                                0 /* maxBufLen */,
+                                NULL /* *usedBufLen */);
                         ])
                 ],
                 [


### PR DESCRIPTION
We were using internal CoreFoundation APIs to convert between unicode
string encodings, which prevented the code from bulding against
public SDKs. Switch over to a  standard CFStringCreate + CFStringGetBytes
pattern that utilizes only public APIs.

Based on a patch by Tim Perfitt <tperfitt@twocanoes.com>.